### PR TITLE
Feature/increase turn template sizes

### DIFF
--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -78,48 +78,48 @@ var Config = function() {
         },
         "right-1": {
             imagePath: "img/move-templates/turn-1-right.png",
-            height: 50,
-            width: 50,
+            height: 57.5,
+            width: 57.5,
             type: "right",
             distance: 1,
             endRotation: 90
         },
         "left-1": {
             imagePath: "img/move-templates/turn-1-left.png",
-            height: 50,
-            width: 50,
+            height: 57.5,
+            width: 57.5,
             type: "left",
             distance: 1,
             endRotation: 270
         },
         "right-2": {
             imagePath: "img/move-templates/turn-2-right.png",
-            height: 75,
-            width: 75,
+            height: 86.25,
+            width: 86.25,
             type: "right",
             distance: 2,
             endRotation: 90
         },
         "left-2": {
             imagePath: "img/move-templates/turn-2-left.png",
-            height: 75,
-            width: 75,
+            height: 86.25,
+            width: 86.25,
             type: "left",
             distance: 2,
             endRotation: 270
         },
         "right-3": {
             imagePath: "img/move-templates/turn-3-right.png",
-            height: 100,
-            width: 100,
+            height: 115,
+            width: 115,
             type: "right",
             distance: 3,
             endRotation: 90
         },
         "left-3": {
             imagePath: "img/move-templates/turn-3-left.png",
-            height: 100,
-            width: 100,
+            height: 115,
+            width: 115,
             type: "left",
             distance: 3,
             endRotation: 270

--- a/src/config/Config.js
+++ b/src/config/Config.js
@@ -76,6 +76,7 @@ var Config = function() {
             distance: 5,
             endRotation: 0
         },
+        // turns are 15% more than originally (50 -> 57.5, 75 -> 86.25, 100 -> 115)
         "right-1": {
             imagePath: "img/move-templates/turn-1-right.png",
             height: 57.5,


### PR DESCRIPTION
- turn templates were slightly undersized to make the math easier when initially implementing
- they are now 15% larger to better reflect their correct size
